### PR TITLE
Use `load.name` when creating accessory instances

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -93,8 +93,8 @@ export class FellerWiserPlatform implements DynamicPlatformPlugin {
                 new Dimmer(this, existingAccessory);
             }
           } else {
-            this.log.info('Adding new accessory:', load.device);
-            const accessory = new this.api.platformAccessory(load.device, uuid);
+            this.log.info('Adding new accessory:', load.name, load.device);
+            const accessory = new this.api.platformAccessory(load.name, uuid);
             accessory.context.load = load;
             switch (load.type) {
               case 'onoff':


### PR DESCRIPTION
Mit diesem PR wird der Names ein loads als `displayName` für Accessory-Objekte genutzt. Damit stimmen die Namen in der Home-App